### PR TITLE
D3b 1422 care plan transformer

### DIFF
--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -200,6 +200,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanSupportingInfoTransformer,
     CarePlanGoalTransformer,
     CarePlanNoteTransformer,
+    CarePlanActivityTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -396,5 +397,6 @@ transformers = {
         CarePlanSupportingInfoTransformer,
         CarePlanGoalTransformer,
         CarePlanNoteTransformer,
+        CarePlanActivityTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -195,6 +195,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanPartOfTransformer,
     CarePlanCategoryTransformer,
     CarePlanContributorTransformer,
+    CarePlanCareTeamTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -386,5 +387,6 @@ transformers = {
         CarePlanPartOfTransformer,
         CarePlanCategoryTransformer,
         CarePlanContributorTransformer,
+        CarePlanCareTeamTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -191,6 +191,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanInstantiatesCanonicalTransformer,
     CarePlanInstantiatesUriTransformer,
     CarePlanBasedOnTransformer,
+    CarePlanReplacesTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -378,5 +379,6 @@ transformers = {
         CarePlanInstantiatesCanonicalTransformer,
         CarePlanInstantiatesUriTransformer,
         CarePlanBasedOnTransformer,
+        CarePlanReplacesTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -192,6 +192,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanInstantiatesUriTransformer,
     CarePlanBasedOnTransformer,
     CarePlanReplacesTransformer,
+    CarePlanPartOfTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -380,5 +381,6 @@ transformers = {
         CarePlanInstantiatesUriTransformer,
         CarePlanBasedOnTransformer,
         CarePlanReplacesTransformer,
+        CarePlanPartOfTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -199,6 +199,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanAddressesTransformer,
     CarePlanSupportingInfoTransformer,
     CarePlanGoalTransformer,
+    CarePlanNoteTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -394,5 +395,6 @@ transformers = {
         CarePlanAddressesTransformer,
         CarePlanSupportingInfoTransformer,
         CarePlanGoalTransformer,
+        CarePlanNoteTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -197,6 +197,8 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanContributorTransformer,
     CarePlanCareTeamTransformer,
     CarePlanAddressesTransformer,
+    CarePlanSupportingInfoTransformer,
+    CarePlanGoalTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -390,5 +392,7 @@ transformers = {
         CarePlanContributorTransformer,
         CarePlanCareTeamTransformer,
         CarePlanAddressesTransformer,
+        CarePlanSupportingInfoTransformer,
+        CarePlanGoalTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -185,6 +185,10 @@ from radiant_fhir_transform_cli.transform.classes.provenance import (
     ProvenanceSignatureTransformer,
 )
 
+from radiant_fhir_transform_cli.transform.classes.care_plan import (
+    CarePlanTransformer,
+)
+
 # Map FHIR resource type to its transformer class
 transformers = {
     "Patient": [PatientTransformer],
@@ -363,5 +367,8 @@ transformers = {
         ProvenanceAgentTransformer,
         ProvenanceEntityTransformer,
         ProvenanceSignatureTransformer,
+    ],
+    "CarePlan": [
+        CarePlanTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -188,6 +188,7 @@ from radiant_fhir_transform_cli.transform.classes.provenance import (
 from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanTransformer,
     CarePlanIdentifierTransformer,
+    CarePlanInstantiatesCanonicalTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -372,5 +373,6 @@ transformers = {
     "CarePlan": [
         CarePlanTransformer,
         CarePlanIdentifierTransformer,
+        CarePlanInstantiatesCanonicalTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -190,6 +190,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanIdentifierTransformer,
     CarePlanInstantiatesCanonicalTransformer,
     CarePlanInstantiatesUriTransformer,
+    CarePlanBasedOnTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -376,5 +377,6 @@ transformers = {
         CarePlanIdentifierTransformer,
         CarePlanInstantiatesCanonicalTransformer,
         CarePlanInstantiatesUriTransformer,
+        CarePlanBasedOnTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -194,6 +194,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanReplacesTransformer,
     CarePlanPartOfTransformer,
     CarePlanCategoryTransformer,
+    CarePlanContributorTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -384,5 +385,6 @@ transformers = {
         CarePlanReplacesTransformer,
         CarePlanPartOfTransformer,
         CarePlanCategoryTransformer,
+        CarePlanContributorTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -189,6 +189,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanTransformer,
     CarePlanIdentifierTransformer,
     CarePlanInstantiatesCanonicalTransformer,
+    CarePlanInstantiatesUriTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -374,5 +375,6 @@ transformers = {
         CarePlanTransformer,
         CarePlanIdentifierTransformer,
         CarePlanInstantiatesCanonicalTransformer,
+        CarePlanInstantiatesUriTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -193,6 +193,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanBasedOnTransformer,
     CarePlanReplacesTransformer,
     CarePlanPartOfTransformer,
+    CarePlanCategoryTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -382,5 +383,6 @@ transformers = {
         CarePlanBasedOnTransformer,
         CarePlanReplacesTransformer,
         CarePlanPartOfTransformer,
+        CarePlanCategoryTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -187,6 +187,7 @@ from radiant_fhir_transform_cli.transform.classes.provenance import (
 
 from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanTransformer,
+    CarePlanIdentifierTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -370,5 +371,6 @@ transformers = {
     ],
     "CarePlan": [
         CarePlanTransformer,
+        CarePlanIdentifierTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -196,6 +196,7 @@ from radiant_fhir_transform_cli.transform.classes.care_plan import (
     CarePlanCategoryTransformer,
     CarePlanContributorTransformer,
     CarePlanCareTeamTransformer,
+    CarePlanAddressesTransformer,
 )
 
 # Map FHIR resource type to its transformer class
@@ -388,5 +389,6 @@ transformers = {
         CarePlanCategoryTransformer,
         CarePlanContributorTransformer,
         CarePlanCareTeamTransformer,
+        CarePlanAddressesTransformer,
     ],
 }

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -8,3 +8,4 @@ from .care_plan_based_on import CarePlanBasedOnTransformer
 from .care_plan_replaces import CarePlanReplacesTransformer
 from .care_plan_part_of import CarePlanPartOfTransformer
 from .care_plan_category import CarePlanCategoryTransformer
+from .care_plan_contributor import CarePlanContributorTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -10,3 +10,4 @@ from .care_plan_part_of import CarePlanPartOfTransformer
 from .care_plan_category import CarePlanCategoryTransformer
 from .care_plan_contributor import CarePlanContributorTransformer
 from .care_plan_care_team import CarePlanCareTeamTransformer
+from .care_plan_addresses import CarePlanAddressesTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -13,3 +13,4 @@ from .care_plan_care_team import CarePlanCareTeamTransformer
 from .care_plan_addresses import CarePlanAddressesTransformer
 from .care_plan_supporting_info import CarePlanSupportingInfoTransformer
 from .care_plan_goal import CarePlanGoalTransformer
+from .care_plan_note import CarePlanNoteTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -11,3 +11,5 @@ from .care_plan_category import CarePlanCategoryTransformer
 from .care_plan_contributor import CarePlanContributorTransformer
 from .care_plan_care_team import CarePlanCareTeamTransformer
 from .care_plan_addresses import CarePlanAddressesTransformer
+from .care_plan_supporting_info import CarePlanSupportingInfoTransformer
+from .care_plan_goal import CarePlanGoalTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -6,3 +6,4 @@ from .care_plan_instantiates_canonical import (
 from .care_plan_instantiates_uri import CarePlanInstantiatesUriTransformer
 from .care_plan_based_on import CarePlanBasedOnTransformer
 from .care_plan_replaces import CarePlanReplacesTransformer
+from .care_plan_part_of import CarePlanPartOfTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -3,3 +3,4 @@ from .care_plan_identifier import CarePlanIdentifierTransformer
 from .care_plan_instantiates_canonical import (
     CarePlanInstantiatesCanonicalTransformer,
 )
+from .care_plan_instantiates_uri import CarePlanInstantiatesUriTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -14,3 +14,4 @@ from .care_plan_addresses import CarePlanAddressesTransformer
 from .care_plan_supporting_info import CarePlanSupportingInfoTransformer
 from .care_plan_goal import CarePlanGoalTransformer
 from .care_plan_note import CarePlanNoteTransformer
+from .care_plan_activity import CarePlanActivityTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -1,2 +1,5 @@
 from .care_plan import CarePlanTransformer
 from .care_plan_identifier import CarePlanIdentifierTransformer
+from .care_plan_instantiates_canonical import (
+    CarePlanInstantiatesCanonicalTransformer,
+)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -1,0 +1,1 @@
+from .care_plan import CarePlanTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -4,3 +4,4 @@ from .care_plan_instantiates_canonical import (
     CarePlanInstantiatesCanonicalTransformer,
 )
 from .care_plan_instantiates_uri import CarePlanInstantiatesUriTransformer
+from .care_plan_based_on import CarePlanBasedOnTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -1,1 +1,2 @@
 from .care_plan import CarePlanTransformer
+from .care_plan_identifier import CarePlanIdentifierTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -9,3 +9,4 @@ from .care_plan_replaces import CarePlanReplacesTransformer
 from .care_plan_part_of import CarePlanPartOfTransformer
 from .care_plan_category import CarePlanCategoryTransformer
 from .care_plan_contributor import CarePlanContributorTransformer
+from .care_plan_care_team import CarePlanCareTeamTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -5,3 +5,4 @@ from .care_plan_instantiates_canonical import (
 )
 from .care_plan_instantiates_uri import CarePlanInstantiatesUriTransformer
 from .care_plan_based_on import CarePlanBasedOnTransformer
+from .care_plan_replaces import CarePlanReplacesTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/__init__.py
@@ -7,3 +7,4 @@ from .care_plan_instantiates_uri import CarePlanInstantiatesUriTransformer
 from .care_plan_based_on import CarePlanBasedOnTransformer
 from .care_plan_replaces import CarePlanReplacesTransformer
 from .care_plan_part_of import CarePlanPartOfTransformer
+from .care_plan_category import CarePlanCategoryTransformer

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan.py
@@ -1,0 +1,101 @@
+"""
+FHIR CarePlan transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    {
+        "fhir_path": "id",
+        "columns": {"id": {"type": "str"}},
+    },
+    {
+        "fhir_path": "resourceType",
+        "columns": {"resource_type": {"type": "str"}},
+    },
+    {
+        "fhir_path": "status",
+        "columns": {"status": {"type": "str"}},
+    },
+    {
+        "fhir_path": "intent",
+        "columns": {"intent": {"type": "str"}},
+    },
+    {
+        "fhir_path": "title",
+        "columns": {"title": {"type": "str"}},
+    },
+    {
+        "fhir_path": "description",
+        "columns": {"description": {"type": "str"}},
+    },
+    {
+        "fhir_path": "subject",
+        "fhir_reference": "subject_reference",
+        "columns": {
+            "subject_reference": {
+                "fhir_key": "reference",
+                "type": "str",
+            },
+            "subject_display": {"fhir_key": "display", "type": "str"},
+            "subject_type": {"fhir_key": "type", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "encounter",
+        "fhir_reference": "encounter_reference",
+        "columns": {
+            "encounter_reference": {
+                "fhir_key": "reference",
+                "type": "str",
+            },
+            "encounter_display": {"fhir_key": "display", "type": "str"},
+            "encounter_type": {"fhir_key": "type", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "period",
+        "columns": {
+            "period_start": {"fhir_key": "start", "type": "datetime"},
+            "period_end": {"fhir_key": "end", "type": "datetime"},
+        },
+    },
+    {
+        "fhir_path": "created",
+        "columns": {"created": {"type": "datetime"}},
+    },
+    {
+        "fhir_path": "author",
+        "fhir_reference": "author_reference",
+        "columns": {
+            "author_reference": {"fhir_key": "reference", "type": "str"},
+            "author_type": {"fhir_key": "type", "type": "str"},
+            "author_display": {"fhir_key": "display", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanTransformer(FhirResourceTransformer):
+    """
+    A transformer class for the 'CarePlan' resource in FHIR.
+
+    Transform CarePlan JSON objects into flat dictionaries representing
+    rows in an output CSV file
+
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed
+        transform_dict (dict): The transformation dictionary used to map
+          and transform the resource data
+
+    Methods:
+        __init__(self):
+            Initializes the CarePlanTransformer instance with the resource
+            type 'CarePlan' and a transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", None, TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_activity.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_activity.py
@@ -1,0 +1,331 @@
+"""
+FHIR CarePlan Activity transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "activity",
+        "columns": {
+            "activity_outcome_codeable_concept": {
+                "fhir_key": "outcomeCodeableConcept",
+                "type": "str",
+            },
+            "activity_outcome_reference": {
+                "fhir_key": "outcomeReference",
+                "type": "str",
+            },
+            "activity_outcome_progress": {
+                "fhir_key": "progress",
+                "type": "str",
+            },
+            "activity_reference_reference": {
+                "fhir_key": "reference.reference",
+                "type": "str",
+            },
+            "activity_reference.display": {
+                "fhir_key": "reference.display",
+                "type": "str",
+            },
+            "activity_reference.type": {
+                "fhir_key": "reference.type",
+                "type": "str",
+            },
+            "activity_detail_kind": {"fhir_key": "detail.kind", "type": "str"},
+            "activity_detail_instantiates_canonical": {
+                "fhir_key": "detail.instantiatesCanonical",
+                "type": "str",
+            },
+            "activity_detail_instantiates_uri": {
+                "fhir_key": "detail.instantiatesUri",
+                "type": "str",
+            },
+            "activity_detail_code_coding": {
+                "fhir_key": "detail.code.coding",
+                "type": "str",
+            },
+            "activity_detail_code_text": {
+                "fhir_key": "detail.code.text",
+                "type": "str",
+            },
+            "activity_detail_reason_code": {
+                "fhir_key": "detail.reasonCode",
+                "type": "str",
+            },
+            "activity_detail_reason_reference": {
+                "fhir_key": "detail.reasonReference",
+                "type": "str",
+            },
+            "activity_detail_goal": {"fhir_key": "detail.goal", "type": "str"},
+            "activity_detail_status": {
+                "fhir_key": "detail.status",
+                "type": "str",
+            },
+            "activity_detail_status_reason": {
+                "fhir_key": "detail.statusReason",
+                "type": "str",
+            },
+            "activity_detail_do_not_perform": {
+                "fhir_key": "detail.doNotPerform",
+                "type": "bool",
+            },
+            # start Scheduled element
+            # scheduledTiming
+            "activity_detail_scheduled_timing_event": {
+                "fhir_key": "detail.scheduledTiming.event",
+                "type": "datetime",
+            },
+            "activity_detail_scheduled_timing_code": {
+                "fhir_key": "detail.scheduledTiming.code",
+                "type": "str",
+            },  # this is at the end of the r4 spec but listing it here for easy tracking
+            # scheduledTiming.repeat.boundsDuration
+            "activity_detail_scheduled_timing_repeat_bounds_duration_value": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsDuration.value",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_duration_comparator": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsDuration.comparator",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_duration_unit": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsDuration.unit",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_duration_system": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsDuration.system",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_duration_code": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsDuration.code",
+                "type": "str",
+            },
+            # scheduledTiming.repeat.boundsRange
+            "activity_detail_scheduled_timing_repeat_bounds_range_low_value": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.low.value",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_range_low_unit": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.low.value",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_range_low_system": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.low.system",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_range_low_code": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.low.code",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_range_high_value": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.high.value",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_range_high_unit": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.high.value",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_range_high_system": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.high.system",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_range_high_code": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsRange.high.code",
+                "type": "str",
+            },
+            # scheduledTiming.repeat.boundsPeriod
+            "activity_detail_scheduled_timing_repeat_bounds_period_start": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsPeriod.start",
+                "type": "datetime",
+            },
+            "activity_detail_scheduled_timing_repeat_bounds_period_end": {
+                "fhir_key": "detail.scheduledTiming.repeat.boundsPeriod.end",
+                "type": "datetime",
+            },
+            # scheduledTiming.repeat
+            "activity_detail_scheduled_timing_repeat_count": {
+                "fhir_key": "detail.scheduledTiming.repeat.count",
+                "type": "int",
+            },
+            "activity_detail_scheduled_timing_repeat_count_max": {
+                "fhir_key": "detail.scheduledTiming.repeat.countMax",
+                "type": "int",
+            },
+            "activity_detail_scheduled_timing_repeat_duration": {
+                "fhir_key": "detail.scheduledTiming.repeat.duration",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_duration_max": {
+                "fhir_key": "detail.scheduledTiming.repeat.durationMax",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_duration_unit": {
+                "fhir_key": "detail.scheduledTiming.repeat.durationUnit",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_frequency": {
+                "fhir_key": "detail.scheduledTiming.repeat.frequency",
+                "type": "int",
+            },
+            "activity_detail_scheduled_timing_repeat_frequency_max": {
+                "fhir_key": "detail.scheduledTiming.repeat.frequencyMax",
+                "type": "int",
+            },
+            "activity_detail_scheduled_timing_repeat_period": {
+                "fhir_key": "detail.scheduledTiming.repeat.duration",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_period_max": {
+                "fhir_key": "detail.scheduledTiming.repeat.periodMax",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_period_unit": {
+                "fhir_key": "detail.scheduledTiming.repeat.periodUnit",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_day_of_week": {
+                "fhir_key": "detail.scheduledTiming.repeat.dayOfWeek",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_time_of_day": {
+                "fhir_key": "detail.scheduledTiming.repeat.timeOfDay",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_when": {
+                "fhir_key": "detail.scheduledTiming.repeat.when",
+                "type": "str",
+            },
+            "activity_detail_scheduled_timing_repeat_offset": {
+                "fhir_key": "detail.scheduledTiming.repeat.offset",
+                "type": "str",
+            },
+            # scheduledPeriod
+            "activity_detail_scheduled_period_start": {
+                "fhir_key": "detail.scheduledPeriod.start",
+                "type": "datetime",
+            },
+            "activity_detail_scheduled_period_end": {
+                "fhir_key": "detail.scheduledPeriod.end",
+                "type": "datetime",
+            },
+            # scheduledString
+            "activity_detail_scheduled_string": {
+                "fhir_key": "detail.scheduledString",
+                "type": "str",
+            },
+            # end Scheduled element
+            "activity_detail_location_reference": {
+                "fhir_key": "detail.location.reference",
+                "type": "str",
+            },
+            "activity_detail_location_type": {
+                "fhir_key": "detail.location.type",
+                "type": "str",
+            },
+            "activity_detail_location_display": {
+                "fhir_key": "detail.location.display",
+                "type": "str",
+            },
+            "activity_detail_performer": {
+                "fhir_key": "detail.performer",
+                "type": "str",
+            },
+            "activity_detail_product_codeable_concept_text": {
+                "fhir_key": "detail.productCodeableConcept.text",
+                "type": "str",
+            },
+            "activity_detail_product_codeable_concept_coding": {
+                "fhir_key": "detail.productCodeableConcept.coding",
+                "type": "str",
+            },
+            "activity_detail_product_reference_reference": {
+                "fhir_key": "detail.productReference.reference",
+                "type": "str",
+            },
+            "activity_detail_product_reference_display": {
+                "fhir_key": "detail.productReference.display",
+                "type": "str",
+            },
+            "activity_detail_product_reference_type": {
+                "fhir_key": "detail.productReference.type",
+                "type": "str",
+            },
+            "activity_detail_daily_amount_value": {
+                "fhir_key": "detail.dailyAmount.value",
+                "type": "str",
+            },
+            "activity_detail_daily_amount_unit": {
+                "fhir_key": "detail.dailyAmount.unit",
+                "type": "str",
+            },
+            "activity_detail_daily_amount_system": {
+                "fhir_key": "detail.dailyAmount.system",
+                "type": "str",
+            },
+            "activity_detail_daily_amount_code": {
+                "fhir_key": "detail.dailyAmount.code",
+                "type": "str",
+            },
+            "activity_detail_quantity_value": {
+                "fhir_key": "detail.quantity.value",
+                "type": "str",
+            },
+            "activity_detail_quantity_unit": {
+                "fhir_key": "detail.quantity.unit",
+                "type": "str",
+            },
+            "activity_detail_quantity_system": {
+                "fhir_key": "detail.quantity.system",
+                "type": "str",
+            },
+            "activity_detail_quantity_code": {
+                "fhir_key": "detail.quantity.code",
+                "type": "str",
+            },
+            "activity_detail_description": {
+                "fhir_key": "detail.description",
+                "type": "str",
+            },
+        },
+    },
+]
+
+
+class CarePlanActivityTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'activity' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'activity' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('activity').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanActivityTransformer instance with the resource type 'CarePlan',
+            subtype 'activity', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "activity", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_addresses.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_addresses.py
@@ -1,0 +1,55 @@
+"""
+FHIR CarePlan addresses transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "addresses",
+        "columns": {
+            "addresses_reference": {"fhir_key": "reference", "type": "str"},
+            "addresses_display": {"fhir_key": "display", "type": "str"},
+            "addresses_type": {"fhir_key": "type", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanAddressesTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'addresses' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'addresses' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('addresses').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanAddressesTransformer instance with the resource type 'CarePlan',
+            subtype 'addresses', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "addresses", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_based_on.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_based_on.py
@@ -1,0 +1,64 @@
+"""
+FHIR CarePlan Based On transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "basedOn",
+        "fhir_reference": "based_on_reference",
+        "columns": {
+            "based_on_reference": {
+                "fhir_key": "reference",
+                "type": "str",
+            },
+            "based_on_display": {
+                "fhir_key": "display",
+                "type": "str",
+            },
+            "based_on_type": {
+                "fhir_key": "type",
+                "type": "str",
+            },
+        },
+    },
+]
+
+
+class CarePlanBasedOnTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'basedOn' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'basedOn' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('based_on').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanBasedOnTransformer instance with the resource type 'CarePlan',
+            subtype 'based_on', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "based_on", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_care_team.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_care_team.py
@@ -1,0 +1,55 @@
+"""
+FHIR CarePlan careTeam transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "careTeam",
+        "columns": {
+            "care_team_reference": {"fhir_key": "reference", "type": "str"},
+            "care_team_display": {"fhir_key": "display", "type": "str"},
+            "care_team_type": {"fhir_key": "type", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanCareTeamTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'careTeam' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'careTeam' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('care_team').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanCareTeamTransformer instance with the resource type 'CarePlan',
+            subtype 'care_team', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "care_team", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_category.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_category.py
@@ -1,0 +1,54 @@
+"""
+FHIR CarePlan Category transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "category",
+        "columns": {
+            "category_coding": {"fhir_key": "coding", "type": "str"},
+            "category_text": {"fhir_key": "text", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanCategoryTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'category' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'category' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('category').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanCategoryTransformer instance with the resource type 'CarePlan',
+            subtype 'category', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "category", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_contributor.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_contributor.py
@@ -1,0 +1,55 @@
+"""
+FHIR CarePlan Contributor transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "contributor",
+        "columns": {
+            "contributor_reference": {"fhir_key": "reference", "type": "str"},
+            "contributor_display": {"fhir_key": "display", "type": "str"},
+            "contributor_type": {"fhir_key": "type", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanContributorTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'contributor' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'contributor' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('contributor').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanContributorTransformer instance with the resource type 'CarePlan',
+            subtype 'contributor', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "contributor", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_goal.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_goal.py
@@ -1,0 +1,55 @@
+"""
+FHIR CarePlan Goal transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "goal",
+        "columns": {
+            "goal_reference": {"fhir_key": "reference", "type": "str"},
+            "goal_display": {"fhir_key": "display", "type": "str"},
+            "goal_type": {"fhir_key": "type", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanGoalTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'goal' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'goal' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('goal').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanGoalTransformer instance with the resource type 'CarePlan',
+            subtype 'goal', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "goal", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_identifier.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_identifier.py
@@ -1,0 +1,61 @@
+"""
+FHIR CarePlan Identifier transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "identifier",
+        "columns": {
+            "identifier_type_text": {"fhir_key": "type.text", "type": "str"},
+            "identifier_system": {"fhir_key": "system", "type": "str"},
+            "identifier_value": {"fhir_key": "value", "type": "str"},
+            "identifier_use": {"fhir_key": "use", "type": "str"},
+            "identifier_period_start": {
+                "fhir_key": "period.start",
+                "type": "str",
+            },
+            "identifier_period_end": {"fhir_key": "period.end", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanIdentifierTransformer(FhirResourceTransformer):
+    """
+    A transformer class for the 'CarePlan' resource in FHIR, focusing on the 'identifier' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'identifier' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('identifier').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanIdentifierTransformer instance with the resource type 'CarePlan',
+            subtype 'identifier', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "identifier", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_instantiates_canonical.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_instantiates_canonical.py
@@ -1,0 +1,53 @@
+"""
+FHIR CarePlan InstantiatesCanonical transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "instantiatesCanonical",
+        "columns": {
+            "instantiates_canonical": {"type": "str"},
+        },
+    },
+]
+
+
+class CarePlanInstantiatesCanonicalTransformer(FhirResourceTransformer):
+    """
+    A transformer class for the 'CarePlan' resource in FHIR, focusing on the 'instantiatesCanonical' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'instantiatesCanonical' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('instantiates_canonical').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanInstantiatesCanonicalTransformer instance with the resource type 'CarePlan',
+            subtype 'instantiates_canonical', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "instantiates_canonical", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_instantiates_uri.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_instantiates_uri.py
@@ -1,0 +1,53 @@
+"""
+FHIR CarePlan InstantiatesUri transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "instantiatesUri",
+        "columns": {
+            "instantiates_uri": {"type": "str"},
+        },
+    },
+]
+
+
+class CarePlanInstantiatesUriTransformer(FhirResourceTransformer):
+    """
+    A transformer class for the 'CarePlan' resource in FHIR, focusing on the 'instantiatesUri' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'instantiatesUri' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('instantiates_uri').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanInstantiatesUriTransformer instance with the resource type 'CarePlan',
+            subtype 'instantiates_uri', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "instantiates_uri", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_note.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_note.py
@@ -1,0 +1,67 @@
+"""
+FHIR CarePlan Note transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "note",
+        "columns": {
+            "note_text": {"fhir_key": "text", "type": "str"},
+            "note_author_string": {"fhir_key": "authorString", "type": "str"},
+            "note_author_reference_reference": {
+                "fhir_key": "authorReference.reference",
+                "type": "str",
+            },
+            "note_author_reference_display": {
+                "fhir_key": "authorReference.display",
+                "type": "str",
+            },
+            "note_author_reference_type": {
+                "fhir_key": "authorReference.type",
+                "type": "str",
+            },
+            "note_time": {"fhir_key": "time", "type": "datetime"},
+        },
+    },
+]
+
+
+class CarePlanNoteTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'note' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'note' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('note').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanNoteTransformer instance with the resource type 'CarePlan',
+            subtype 'note', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "note", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_part_of.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_part_of.py
@@ -1,0 +1,64 @@
+"""
+FHIR CarePlan PartOf transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "partOf",
+        "fhir_reference": "part_of_reference",
+        "columns": {
+            "part_of_reference": {
+                "fhir_key": "reference",
+                "type": "str",
+            },
+            "part_of_display": {
+                "fhir_key": "display",
+                "type": "str",
+            },
+            "part_of_type": {
+                "fhir_key": "type",
+                "type": "str",
+            },
+        },
+    },
+]
+
+
+class CarePlanPartOfTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'partOf' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'partOf' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('part_of').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanPartOfTransformer instance with the resource type 'CarePlan',
+            subtype 'part_of', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "part_of", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_replaces.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_replaces.py
@@ -1,0 +1,64 @@
+"""
+FHIR CarePlan Replacestransformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "replaces",
+        "fhir_reference": "replaces_reference",
+        "columns": {
+            "replaces_reference": {
+                "fhir_key": "reference",
+                "type": "str",
+            },
+            "replaces_display": {
+                "fhir_key": "display",
+                "type": "str",
+            },
+            "replaces_type": {
+                "fhir_key": "type",
+                "type": "str",
+            },
+        },
+    },
+]
+
+
+class CarePlanReplacesTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'replaces' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'replaces' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('replaces').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanReplacesTransformer instance with the resource type 'CarePlan',
+            subtype 'replaces', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "replaces", TRANSFORM_SCHEMA)

--- a/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_supporting_info.py
+++ b/radiant_fhir_transform_cli/transform/classes/care_plan/care_plan_supporting_info.py
@@ -1,0 +1,58 @@
+"""
+FHIR CarePlan SupportingInfo transformer
+"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+TRANSFORM_SCHEMA = [
+    # Primary Key
+    {
+        "fhir_path": None,
+        "columns": {
+            "id": {"fhir_key": None, "type": "str"},
+        },
+    },
+    # Foreign Key
+    {
+        "fhir_path": "id",
+        "is_foreign_key": True,
+        "columns": {
+            "care_plan_id": {"fhir_key": "id", "type": "str"},
+        },
+    },
+    {
+        "fhir_path": "supportingInfo",
+        "columns": {
+            "supporting_info_reference": {
+                "fhir_key": "reference",
+                "type": "str",
+            },
+            "supporting_info_display": {"fhir_key": "display", "type": "str"},
+            "supporting_info_type": {"fhir_key": "type", "type": "str"},
+        },
+    },
+]
+
+
+class CarePlanSupportingInfoTransformer(FhirResourceTransformer):
+    """
+    Transformer class for the 'CarePlan' resource in FHIR, focusing on the 'supportingInfo' element.
+
+    This class transforms FHIR CarePlan JSON objects into flat dictionaries suitable for CSV output,
+    extracting and processing information from the 'supportingInfo' field.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being transformed ('CarePlan').
+        subtype (str): Specifies the sub-element of the resource to focus on ('supporting_info').
+        transform_dict (dict): A dictionary defining the mapping and transformation rules for the resource data.
+
+    Methods:
+        __init__():
+            Initializes the CarePlanSupportingInfoTransformer instance with the resource type 'CarePlan',
+            subtype 'supporting_info', and the specified transformation dictionary.
+    """
+
+    def __init__(self):
+        super().__init__("CarePlan", "supporting_info", TRANSFORM_SCHEMA)

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -190,6 +190,7 @@ from tests.data.care_plan import (
     CarePlanReplacesTestHelper,
     CarePlanPartOfTestHelper,
     CarePlanCategoryTestHelper,
+    CarePlanContributorTestHelper,
 )
 
 test_helpers = [
@@ -352,4 +353,5 @@ test_helpers = [
     CarePlanReplacesTestHelper,
     CarePlanPartOfTestHelper,
     CarePlanCategoryTestHelper,
+    CarePlanContributorTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -184,6 +184,7 @@ from tests.data.provenance import (
 from tests.data.care_plan import (
     CarePlanTestHelper,
     CarePlanIdentifierTestHelper,
+    CarePlanInstantiatesCanonicalTestHelper,
 )
 
 test_helpers = [
@@ -340,4 +341,5 @@ test_helpers = [
     ProvenanceSignatureTestHelper,
     CarePlanTestHelper,
     CarePlanIdentifierTestHelper,
+    CarePlanInstantiatesCanonicalTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -188,6 +188,7 @@ from tests.data.care_plan import (
     CarePlanInstantiatesUriTestHelper,
     CarePlanBasedOnTestHelper,
     CarePlanReplacesTestHelper,
+    CarePlanPartOfTestHelper,
 )
 
 test_helpers = [
@@ -348,4 +349,5 @@ test_helpers = [
     CarePlanInstantiatesUriTestHelper,
     CarePlanBasedOnTestHelper,
     CarePlanReplacesTestHelper,
+    CarePlanPartOfTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -191,6 +191,7 @@ from tests.data.care_plan import (
     CarePlanPartOfTestHelper,
     CarePlanCategoryTestHelper,
     CarePlanContributorTestHelper,
+    CarePlanCareTeamTestHelper,
 )
 
 test_helpers = [
@@ -354,4 +355,5 @@ test_helpers = [
     CarePlanPartOfTestHelper,
     CarePlanCategoryTestHelper,
     CarePlanContributorTestHelper,
+    CarePlanCareTeamTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -181,6 +181,9 @@ from tests.data.provenance import (
     ProvenanceEntityTestHelper,
     ProvenanceSignatureTestHelper,
 )
+from tests.data.care_plan import (
+    CarePlanTestHelper,
+)
 
 test_helpers = [
     PatientTestHelper,
@@ -334,4 +337,5 @@ test_helpers = [
     ProvenanceAgentTestHelper,
     ProvenanceEntityTestHelper,
     ProvenanceSignatureTestHelper,
+    CarePlanTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -189,6 +189,7 @@ from tests.data.care_plan import (
     CarePlanBasedOnTestHelper,
     CarePlanReplacesTestHelper,
     CarePlanPartOfTestHelper,
+    CarePlanCategoryTestHelper,
 )
 
 test_helpers = [
@@ -350,4 +351,5 @@ test_helpers = [
     CarePlanBasedOnTestHelper,
     CarePlanReplacesTestHelper,
     CarePlanPartOfTestHelper,
+    CarePlanCategoryTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -186,6 +186,7 @@ from tests.data.care_plan import (
     CarePlanIdentifierTestHelper,
     CarePlanInstantiatesCanonicalTestHelper,
     CarePlanInstantiatesUriTestHelper,
+    CarePlanBasedOnTestHelper,
 )
 
 test_helpers = [
@@ -344,4 +345,5 @@ test_helpers = [
     CarePlanIdentifierTestHelper,
     CarePlanInstantiatesCanonicalTestHelper,
     CarePlanInstantiatesUriTestHelper,
+    CarePlanBasedOnTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -196,6 +196,7 @@ from tests.data.care_plan import (
     CarePlanSupportingInfoTestHelper,
     CarePlanGoalTestHelper,
     CarePlanNoteTestHelper,
+    CarePlanActivityTestHelper,
 )
 
 test_helpers = [
@@ -364,4 +365,5 @@ test_helpers = [
     CarePlanSupportingInfoTestHelper,
     CarePlanGoalTestHelper,
     CarePlanNoteTestHelper,
+    CarePlanActivityTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -193,6 +193,8 @@ from tests.data.care_plan import (
     CarePlanContributorTestHelper,
     CarePlanCareTeamTestHelper,
     CarePlanAddressesTestHelper,
+    CarePlanSupportingInfoTestHelper,
+    CarePlanGoalTestHelper,
 )
 
 test_helpers = [
@@ -358,4 +360,6 @@ test_helpers = [
     CarePlanContributorTestHelper,
     CarePlanCareTeamTestHelper,
     CarePlanAddressesTestHelper,
+    CarePlanSupportingInfoTestHelper,
+    CarePlanGoalTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -195,6 +195,7 @@ from tests.data.care_plan import (
     CarePlanAddressesTestHelper,
     CarePlanSupportingInfoTestHelper,
     CarePlanGoalTestHelper,
+    CarePlanNoteTestHelper,
 )
 
 test_helpers = [
@@ -362,4 +363,5 @@ test_helpers = [
     CarePlanAddressesTestHelper,
     CarePlanSupportingInfoTestHelper,
     CarePlanGoalTestHelper,
+    CarePlanNoteTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -192,6 +192,7 @@ from tests.data.care_plan import (
     CarePlanCategoryTestHelper,
     CarePlanContributorTestHelper,
     CarePlanCareTeamTestHelper,
+    CarePlanAddressesTestHelper,
 )
 
 test_helpers = [
@@ -356,4 +357,5 @@ test_helpers = [
     CarePlanCategoryTestHelper,
     CarePlanContributorTestHelper,
     CarePlanCareTeamTestHelper,
+    CarePlanAddressesTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -185,6 +185,7 @@ from tests.data.care_plan import (
     CarePlanTestHelper,
     CarePlanIdentifierTestHelper,
     CarePlanInstantiatesCanonicalTestHelper,
+    CarePlanInstantiatesUriTestHelper,
 )
 
 test_helpers = [
@@ -342,4 +343,5 @@ test_helpers = [
     CarePlanTestHelper,
     CarePlanIdentifierTestHelper,
     CarePlanInstantiatesCanonicalTestHelper,
+    CarePlanInstantiatesUriTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -183,6 +183,7 @@ from tests.data.provenance import (
 )
 from tests.data.care_plan import (
     CarePlanTestHelper,
+    CarePlanIdentifierTestHelper,
 )
 
 test_helpers = [
@@ -338,4 +339,5 @@ test_helpers = [
     ProvenanceEntityTestHelper,
     ProvenanceSignatureTestHelper,
     CarePlanTestHelper,
+    CarePlanIdentifierTestHelper,
 ]

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -187,6 +187,7 @@ from tests.data.care_plan import (
     CarePlanInstantiatesCanonicalTestHelper,
     CarePlanInstantiatesUriTestHelper,
     CarePlanBasedOnTestHelper,
+    CarePlanReplacesTestHelper,
 )
 
 test_helpers = [
@@ -346,4 +347,5 @@ test_helpers = [
     CarePlanInstantiatesCanonicalTestHelper,
     CarePlanInstantiatesUriTestHelper,
     CarePlanBasedOnTestHelper,
+    CarePlanReplacesTestHelper,
 ]

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -14,3 +14,4 @@ from .care_plan_addresses import CarePlanAddressesTestHelper
 from .care_plan_supporting_info import CarePlanSupportingInfoTestHelper
 from .care_plan_goal import CarePlanGoalTestHelper
 from .care_plan_note import CarePlanNoteTestHelper
+from .care_plan_activity import CarePlanActivityTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -11,3 +11,5 @@ from .care_plan_category import CarePlanCategoryTestHelper
 from .care_plan_contributor import CarePlanContributorTestHelper
 from .care_plan_care_team import CarePlanCareTeamTestHelper
 from .care_plan_addresses import CarePlanAddressesTestHelper
+from .care_plan_supporting_info import CarePlanSupportingInfoTestHelper
+from .care_plan_goal import CarePlanGoalTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -1,2 +1,5 @@
 from .care_plan import CarePlanTestHelper
 from .care_plan_identifier import CarePlanIdentifierTestHelper
+from .care_plan_instantiates_canonical import (
+    CarePlanInstantiatesCanonicalTestHelper,
+)

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -13,3 +13,4 @@ from .care_plan_care_team import CarePlanCareTeamTestHelper
 from .care_plan_addresses import CarePlanAddressesTestHelper
 from .care_plan_supporting_info import CarePlanSupportingInfoTestHelper
 from .care_plan_goal import CarePlanGoalTestHelper
+from .care_plan_note import CarePlanNoteTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -8,3 +8,4 @@ from .care_plan_based_on import CarePlanBasedOnTestHelper
 from .care_plan_replaces import CarePlanReplacesTestHelper
 from .care_plan_part_of import CarePlanPartOfTestHelper
 from .care_plan_category import CarePlanCategoryTestHelper
+from .care_plan_contributor import CarePlanContributorTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -9,3 +9,4 @@ from .care_plan_replaces import CarePlanReplacesTestHelper
 from .care_plan_part_of import CarePlanPartOfTestHelper
 from .care_plan_category import CarePlanCategoryTestHelper
 from .care_plan_contributor import CarePlanContributorTestHelper
+from .care_plan_care_team import CarePlanCareTeamTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -3,3 +3,4 @@ from .care_plan_identifier import CarePlanIdentifierTestHelper
 from .care_plan_instantiates_canonical import (
     CarePlanInstantiatesCanonicalTestHelper,
 )
+from .care_plan_instantiates_uri import CarePlanInstantiatesUriTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -1,0 +1,1 @@
+from .care_plan import CarePlanTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -6,3 +6,4 @@ from .care_plan_instantiates_canonical import (
 from .care_plan_instantiates_uri import CarePlanInstantiatesUriTestHelper
 from .care_plan_based_on import CarePlanBasedOnTestHelper
 from .care_plan_replaces import CarePlanReplacesTestHelper
+from .care_plan_part_of import CarePlanPartOfTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -1,1 +1,2 @@
 from .care_plan import CarePlanTestHelper
+from .care_plan_identifier import CarePlanIdentifierTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -7,3 +7,4 @@ from .care_plan_instantiates_uri import CarePlanInstantiatesUriTestHelper
 from .care_plan_based_on import CarePlanBasedOnTestHelper
 from .care_plan_replaces import CarePlanReplacesTestHelper
 from .care_plan_part_of import CarePlanPartOfTestHelper
+from .care_plan_category import CarePlanCategoryTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -5,3 +5,4 @@ from .care_plan_instantiates_canonical import (
 )
 from .care_plan_instantiates_uri import CarePlanInstantiatesUriTestHelper
 from .care_plan_based_on import CarePlanBasedOnTestHelper
+from .care_plan_replaces import CarePlanReplacesTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -4,3 +4,4 @@ from .care_plan_instantiates_canonical import (
     CarePlanInstantiatesCanonicalTestHelper,
 )
 from .care_plan_instantiates_uri import CarePlanInstantiatesUriTestHelper
+from .care_plan_based_on import CarePlanBasedOnTestHelper

--- a/tests/data/care_plan/__init__.py
+++ b/tests/data/care_plan/__init__.py
@@ -10,3 +10,4 @@ from .care_plan_part_of import CarePlanPartOfTestHelper
 from .care_plan_category import CarePlanCategoryTestHelper
 from .care_plan_contributor import CarePlanContributorTestHelper
 from .care_plan_care_team import CarePlanCareTeamTestHelper
+from .care_plan_addresses import CarePlanAddressesTestHelper

--- a/tests/data/care_plan/care_plan.py
+++ b/tests/data/care_plan/care_plan.py
@@ -1,0 +1,63 @@
+"""
+Test helper class for FHIR resource type CarePlan
+"""
+
+from radiant_fhir_transform_cli.transform.classes.care_plan.care_plan import (
+    CarePlanTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan_resource import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "id": "preg",
+        "resource_type": "CarePlan",
+        "status": "active",
+        "intent": "plan",
+        "title": None,
+        "description": None,
+        "subject_reference": "1",
+        "subject_display": "Eve Everywoman",
+        "subject_type": None,
+        "encounter_reference": None,
+        "encounter_display": None,
+        "encounter_type": None,
+        "period_start": "2013-01-01",
+        "period_end": "2013-10-01",
+        "created": None,
+        "author_reference": None,
+        "author_display": None,
+        "author_type": None,
+    },
+]
+
+
+class CarePlanTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = None
+    transformer = CarePlanTransformer
+    expected_table_name = "care_plan"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_activity.py
+++ b/tests/data/care_plan/care_plan_activity.py
@@ -1,0 +1,379 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype Activity
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanActivityTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "activity_outcome_codeable_concept": None,
+        "activity_outcome_reference": None,
+        "activity_outcome_progress": None,
+        "activity_reference_reference": None,
+        "activity_reference.display": "Prenatal vitamin MedicationRequest",
+        "activity_reference.type": None,
+        "activity_detail_kind": None,
+        "activity_detail_instantiates_canonical": None,
+        "activity_detail_instantiates_uri": None,
+        "activity_detail_code_coding": None,
+        "activity_detail_code_text": None,
+        "activity_detail_reason_code": None,
+        "activity_detail_reason_reference": None,
+        "activity_detail_goal": None,
+        "activity_detail_status": None,
+        "activity_detail_status_reason": None,
+        "activity_detail_do_not_perform": None,
+        # start Scheduled element
+        # scheduledTiming
+        "activity_detail_scheduled_timing_event": None,
+        # scheduledTiming.repeat.boundsDuration
+        "activity_detail_scheduled_timing_repeat_bounds_duration_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_comparator": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_code": None,
+        # scheduledTiming.repeat.boundsRange
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_code": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_code": None,
+        # scheduledTiming.repeat.boundsPeriod
+        "activity_detail_scheduled_timing_repeat_bounds_period_start": None,
+        "activity_detail_scheduled_timing_repeat_bounds_period_end": None,
+        # scheduledTiming.repeat
+        "activity_detail_scheduled_timing_repeat_count": None,
+        "activity_detail_scheduled_timing_repeat_count_max": None,
+        "activity_detail_scheduled_timing_repeat_duration": None,
+        "activity_detail_scheduled_timing_repeat_duration_max": None,
+        "activity_detail_scheduled_timing_repeat_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_frequency": None,
+        "activity_detail_scheduled_timing_repeat_frequency_max": None,
+        "activity_detail_scheduled_timing_repeat_period": None,
+        "activity_detail_scheduled_timing_repeat_period_max": None,
+        "activity_detail_scheduled_timing_repeat_period_unit": None,
+        "activity_detail_scheduled_timing_repeat_day_of_week": None,
+        "activity_detail_scheduled_timing_repeat_time_of_day": None,
+        "activity_detail_scheduled_timing_repeat_when": None,
+        "activity_detail_scheduled_timing_repeat_offset": None,
+        "activity_detail_scheduled_timing_code": None,
+        # scheduledPeriod
+        "activity_detail_scheduled_period_start": None,
+        "activity_detail_scheduled_period_end": None,
+        # scheduledString
+        "activity_detail_scheduled_string": None,
+        # end Scheduled element
+        "activity_detail_location_reference": None,
+        "activity_detail_location_type": None,
+        "activity_detail_location_display": None,
+        "activity_detail_performer": None,
+        "activity_detail_product_codeable_concept_text": None,
+        "activity_detail_product_codeable_concept_coding": None,
+        "activity_detail_product_reference_reference": None,
+        "activity_detail_product_reference_display": None,
+        "activity_detail_product_reference_type": None,
+        "activity_detail_daily_amount_value": None,
+        "activity_detail_daily_amount_unit": None,
+        "activity_detail_daily_amount_system": None,
+        "activity_detail_daily_amount_code": None,
+        "activity_detail_quantity_value": None,
+        "activity_detail_quantity_unit": None,
+        "activity_detail_quantity_system": None,
+        "activity_detail_quantity_code": None,
+        "activity_detail_description": None,
+    },
+    {
+        "care_plan_id": "preg",
+        "activity_outcome_codeable_concept": None,
+        "activity_outcome_reference": None,
+        "activity_outcome_progress": None,
+        "activity_reference_reference": None,
+        "activity_reference.display": None,
+        "activity_reference.type": None,
+        "activity_detail_kind": "Appointment",
+        "activity_detail_instantiates_canonical": None,
+        "activity_detail_instantiates_uri": None,
+        "activity_detail_code_coding": [
+            {"system": "http://example.org/mySystem", "code": "1an"}
+        ],
+        "activity_detail_code_text": "First Antenatal encounter",
+        "activity_detail_reason_code": None,
+        "activity_detail_reason_reference": None,
+        "activity_detail_goal": None,
+        "activity_detail_status": "scheduled",
+        "activity_detail_status_reason": None,
+        "activity_detail_do_not_perform": False,
+        # start Scheduled element
+        # scheduledTiming
+        "activity_detail_scheduled_timing_event": None,
+        # scheduledTiming.repeat.boundsDuration
+        "activity_detail_scheduled_timing_repeat_bounds_duration_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_comparator": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_code": None,
+        # scheduledTiming.repeat.boundsRange
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_code": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_code": None,
+        # scheduledTiming.repeat.boundsPeriod
+        "activity_detail_scheduled_timing_repeat_bounds_period_start": "2013-02-14",
+        "activity_detail_scheduled_timing_repeat_bounds_period_end": "2013-02-28",
+        # scheduledTiming.repeat
+        "activity_detail_scheduled_timing_repeat_count": None,
+        "activity_detail_scheduled_timing_repeat_count_max": None,
+        "activity_detail_scheduled_timing_repeat_duration": None,
+        "activity_detail_scheduled_timing_repeat_duration_max": None,
+        "activity_detail_scheduled_timing_repeat_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_frequency": None,
+        "activity_detail_scheduled_timing_repeat_frequency_max": None,
+        "activity_detail_scheduled_timing_repeat_period": None,
+        "activity_detail_scheduled_timing_repeat_period_max": None,
+        "activity_detail_scheduled_timing_repeat_period_unit": None,
+        "activity_detail_scheduled_timing_repeat_day_of_week": None,
+        "activity_detail_scheduled_timing_repeat_time_of_day": None,
+        "activity_detail_scheduled_timing_repeat_when": None,
+        "activity_detail_scheduled_timing_repeat_offset": None,
+        "activity_detail_scheduled_timing_code": None,
+        # scheduledPeriod
+        "activity_detail_scheduled_period_start": None,
+        "activity_detail_scheduled_period_end": None,
+        # scheduledString
+        "activity_detail_scheduled_string": None,
+        # end Scheduled element
+        "activity_detail_location_reference": None,
+        "activity_detail_location_type": None,
+        "activity_detail_location_display": None,
+        "activity_detail_performer": [
+            {"reference": "#pr1", "display": "Mavis Midwife"}
+        ],
+        "activity_detail_product_codeable_concept_text": None,
+        "activity_detail_product_codeable_concept_coding": None,
+        "activity_detail_product_reference_reference": None,
+        "activity_detail_product_reference_display": None,
+        "activity_detail_product_reference_type": None,
+        "activity_detail_daily_amount_value": None,
+        "activity_detail_daily_amount_unit": None,
+        "activity_detail_daily_amount_system": None,
+        "activity_detail_daily_amount_code": None,
+        "activity_detail_quantity_value": None,
+        "activity_detail_quantity_unit": None,
+        "activity_detail_quantity_system": None,
+        "activity_detail_quantity_code": None,
+        "activity_detail_description": "The first antenatal encounter. This is where a detailed physical examination is performed.             and the pregnanacy discussed with the mother-to-be.",
+    },
+    {
+        "care_plan_id": "preg",
+        "activity_outcome_codeable_concept": None,
+        "activity_outcome_reference": None,
+        "activity_outcome_progress": None,
+        "activity_reference_reference": None,
+        "activity_reference.display": None,
+        "activity_reference.type": None,
+        "activity_detail_kind": "Appointment",
+        "activity_detail_instantiates_canonical": None,
+        "activity_detail_instantiates_uri": None,
+        "activity_detail_code_coding": [
+            {"system": "http://example.org/mySystem", "code": "an"}
+        ],
+        "activity_detail_code_text": "Follow-up Antenatal encounter",
+        "activity_detail_reason_code": None,
+        "activity_detail_reason_reference": None,
+        "activity_detail_goal": None,
+        "activity_detail_status": "not-started",
+        "activity_detail_status_reason": None,
+        "activity_detail_do_not_perform": False,
+        # start Scheduled element
+        # scheduledTiming
+        "activity_detail_scheduled_timing_event": None,
+        # scheduledTiming.repeat.boundsDuration
+        "activity_detail_scheduled_timing_repeat_bounds_duration_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_comparator": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_code": None,
+        # scheduledTiming.repeat.boundsRange
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_code": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_code": None,
+        # scheduledTiming.repeat.boundsPeriod
+        "activity_detail_scheduled_timing_repeat_bounds_period_start": "2013-03-01",
+        "activity_detail_scheduled_timing_repeat_bounds_period_end": "2013-03-14",
+        # scheduledTiming.repeat
+        "activity_detail_scheduled_timing_repeat_count": None,
+        "activity_detail_scheduled_timing_repeat_count_max": None,
+        "activity_detail_scheduled_timing_repeat_duration": None,
+        "activity_detail_scheduled_timing_repeat_duration_max": None,
+        "activity_detail_scheduled_timing_repeat_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_frequency": None,
+        "activity_detail_scheduled_timing_repeat_frequency_max": None,
+        "activity_detail_scheduled_timing_repeat_period": None,
+        "activity_detail_scheduled_timing_repeat_period_max": None,
+        "activity_detail_scheduled_timing_repeat_period_unit": None,
+        "activity_detail_scheduled_timing_repeat_day_of_week": None,
+        "activity_detail_scheduled_timing_repeat_time_of_day": None,
+        "activity_detail_scheduled_timing_repeat_when": None,
+        "activity_detail_scheduled_timing_repeat_offset": None,
+        "activity_detail_scheduled_timing_code": None,
+        # scheduledPeriod
+        "activity_detail_scheduled_period_start": None,
+        "activity_detail_scheduled_period_end": None,
+        # scheduledString
+        "activity_detail_scheduled_string": None,
+        # end Scheduled element
+        "activity_detail_location_reference": None,
+        "activity_detail_location_type": None,
+        "activity_detail_location_display": None,
+        "activity_detail_performer": [
+            {"reference": "#pr1", "display": "Mavis Midwife"}
+        ],
+        "activity_detail_product_codeable_concept_text": None,
+        "activity_detail_product_codeable_concept_coding": None,
+        "activity_detail_product_reference_reference": None,
+        "activity_detail_product_reference_display": None,
+        "activity_detail_product_reference_type": None,
+        "activity_detail_daily_amount_value": None,
+        "activity_detail_daily_amount_unit": None,
+        "activity_detail_daily_amount_system": None,
+        "activity_detail_daily_amount_code": None,
+        "activity_detail_quantity_value": None,
+        "activity_detail_quantity_unit": None,
+        "activity_detail_quantity_system": None,
+        "activity_detail_quantity_code": None,
+        "activity_detail_description": "The second antenatal encounter. Discuss any issues that arose from the first antenatal encounter",
+    },
+    {
+        "care_plan_id": "preg",
+        "activity_outcome_codeable_concept": None,
+        "activity_outcome_reference": None,
+        "activity_outcome_progress": None,
+        "activity_reference_reference": None,
+        "activity_reference.display": None,
+        "activity_reference.type": None,
+        "activity_detail_kind": "Appointment",
+        "activity_detail_instantiates_canonical": None,
+        "activity_detail_instantiates_uri": None,
+        "activity_detail_code_coding": [
+            {"system": "http://example.org/mySystem", "code": "del"}
+        ],
+        "activity_detail_code_text": "Delivery",
+        "activity_detail_reason_code": None,
+        "activity_detail_reason_reference": None,
+        "activity_detail_goal": None,
+        "activity_detail_status": "not-started",
+        "activity_detail_status_reason": None,
+        "activity_detail_do_not_perform": False,
+        # start Scheduled element
+        # scheduledTiming
+        "activity_detail_scheduled_timing_event": None,
+        # scheduledTiming.repeat.boundsDuration
+        "activity_detail_scheduled_timing_repeat_bounds_duration_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_comparator": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_duration_code": None,
+        # scheduledTiming.repeat.boundsRange
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_low_code": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_value": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_unit": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_system": None,
+        "activity_detail_scheduled_timing_repeat_bounds_range_high_code": None,
+        # scheduledTiming.repeat.boundsPeriod
+        "activity_detail_scheduled_timing_repeat_bounds_period_start": "2013-09-01",
+        "activity_detail_scheduled_timing_repeat_bounds_period_end": "2013-09-14",
+        # scheduledTiming.repeat
+        "activity_detail_scheduled_timing_repeat_count": None,
+        "activity_detail_scheduled_timing_repeat_count_max": None,
+        "activity_detail_scheduled_timing_repeat_duration": None,
+        "activity_detail_scheduled_timing_repeat_duration_max": None,
+        "activity_detail_scheduled_timing_repeat_duration_unit": None,
+        "activity_detail_scheduled_timing_repeat_frequency": None,
+        "activity_detail_scheduled_timing_repeat_frequency_max": None,
+        "activity_detail_scheduled_timing_repeat_period": None,
+        "activity_detail_scheduled_timing_repeat_period_max": None,
+        "activity_detail_scheduled_timing_repeat_period_unit": None,
+        "activity_detail_scheduled_timing_repeat_day_of_week": None,
+        "activity_detail_scheduled_timing_repeat_time_of_day": None,
+        "activity_detail_scheduled_timing_repeat_when": None,
+        "activity_detail_scheduled_timing_repeat_offset": None,
+        "activity_detail_scheduled_timing_code": None,
+        # scheduledPeriod
+        "activity_detail_scheduled_period_start": None,
+        "activity_detail_scheduled_period_end": None,
+        # scheduledString
+        "activity_detail_scheduled_string": None,
+        # end Scheduled element
+        "activity_detail_location_reference": None,
+        "activity_detail_location_type": None,
+        "activity_detail_location_display": None,
+        "activity_detail_performer": [
+            {"reference": "#pr1", "display": "Mavis Midwife"}
+        ],
+        "activity_detail_product_codeable_concept_text": None,
+        "activity_detail_product_codeable_concept_coding": None,
+        "activity_detail_product_reference_reference": None,
+        "activity_detail_product_reference_display": None,
+        "activity_detail_product_reference_type": None,
+        "activity_detail_daily_amount_value": None,
+        "activity_detail_daily_amount_unit": None,
+        "activity_detail_daily_amount_system": None,
+        "activity_detail_daily_amount_code": None,
+        "activity_detail_quantity_value": None,
+        "activity_detail_quantity_unit": None,
+        "activity_detail_quantity_system": None,
+        "activity_detail_quantity_code": None,
+        "activity_detail_description": "The delivery.",
+    },
+]
+
+
+class CarePlanActivityTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "activity"
+    transformer = CarePlanActivityTransformer
+    expected_table_name = "care_plan_activity"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_addresses.py
+++ b/tests/data/care_plan/care_plan_addresses.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype Addresses
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanAddressesTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "addresses_reference": "#p1",
+        "addresses_display": "pregnancy",
+        "addresses_type": None,
+    },
+]
+
+
+class CarePlanAddressesTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "addresses"
+    transformer = CarePlanAddressesTransformer
+    expected_table_name = "care_plan_addresses"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_based_on.py
+++ b/tests/data/care_plan/care_plan_based_on.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype basedOn
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanBasedOnTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "based_on_reference": None,
+        "based_on_display": "Management of Type 2 Diabetes",
+        "based_on_type": None,
+    },
+]
+
+
+class CarePlanBasedOnTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "based_on"
+    transformer = CarePlanBasedOnTransformer
+    expected_table_name = "care_plan_based_on"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_care_team.py
+++ b/tests/data/care_plan/care_plan_care_team.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype CareTeam
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanCareTeamTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "care_team_reference": "#careteam",
+        "care_team_display": None,
+        "care_team_type": None,
+    },
+]
+
+
+class CarePlanCareTeamTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "care_team"
+    transformer = CarePlanCareTeamTransformer
+    expected_table_name = "care_plan_care_team"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_category.py
+++ b/tests/data/care_plan/care_plan_category.py
@@ -1,0 +1,48 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype category
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanCategoryTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "category_coding": None,
+        "category_text": "Weight management plan",
+    },
+]
+
+
+class CarePlanCategoryTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "category"
+    transformer = CarePlanCategoryTransformer
+    expected_table_name = "care_plan_category"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_contributor.py
+++ b/tests/data/care_plan/care_plan_contributor.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype contributor
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanContributorTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "contributor_reference": "Practitioner/example",
+        "contributor_display": "Peter Example",
+        "contributor_type": None,
+    },
+]
+
+
+class CarePlanContributorTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "contributor"
+    transformer = CarePlanContributorTransformer
+    expected_table_name = "care_plan_contributor"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_goal.py
+++ b/tests/data/care_plan/care_plan_goal.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype Goal
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanGoalTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "goal_reference": "#goal",
+        "goal_display": None,
+        "goal_type": None,
+    },
+]
+
+
+class CarePlanGoalTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "goal"
+    transformer = CarePlanGoalTransformer
+    expected_table_name = "care_plan_goal"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_identifier.py
+++ b/tests/data/care_plan/care_plan_identifier.py
@@ -1,0 +1,52 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype identifier
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanIdentifierTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "identifier_type_text": None,
+        "identifier_system": "http://www.bmc.nl/zorgportal/identifiers/careplans",
+        "identifier_value": "CP2903",
+        "identifier_period_start": None,
+        "identifier_period_end": None,
+        "identifier_use": "official",
+    },
+]
+
+
+class CarePlanIdentifierTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "identifier"
+    transformer = CarePlanIdentifierTransformer
+    expected_table_name = "care_plan_identifier"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_instantiates_canonical.py
+++ b/tests/data/care_plan/care_plan_instantiates_canonical.py
@@ -1,0 +1,47 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype InstantiatesCanonical
+"""
+
+from radiant_fhir_transform_cli.transform.classes.care_plan import (
+    CarePlanInstantiatesCanonicalTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan_resource import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "instantiates_canonical": "http://example.org/fhir/CarePlanDefinition/KDN5",
+    }
+]
+
+
+class CarePlanInstantiatesCanonicalTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "instantiates_canonical"
+    transformer = CarePlanInstantiatesCanonicalTransformer
+    expected_table_name = "care_plan_instantiates_canonical"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_instantiates_uri.py
+++ b/tests/data/care_plan/care_plan_instantiates_uri.py
@@ -1,0 +1,47 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype InstantiatesUri
+"""
+
+from radiant_fhir_transform_cli.transform.classes.care_plan import (
+    CarePlanInstantiatesUriTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan_resource import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "instantiates_uri": "http://example.org/protocol-for-obesity",
+    }
+]
+
+
+class CarePlanInstantiatesUriTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "instantiates_uri"
+    transformer = CarePlanInstantiatesUriTransformer
+    expected_table_name = "care_plan_instantiates_uri"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_note.py
+++ b/tests/data/care_plan/care_plan_note.py
@@ -1,0 +1,52 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype note
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanNoteTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "note_text": "Patient family is not ready to commit to goal setting at this time.  Goal setting will be addressed in the future",
+        "note_author_string": None,
+        "note_author_reference_reference": None,
+        "note_author_reference_display": None,
+        "note_author_reference_type": None,
+        "note_time": "2014-02-14",
+    },
+]
+
+
+class CarePlanNoteTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "note"
+    transformer = CarePlanNoteTransformer
+    expected_table_name = "care_plan_note"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_part_of.py
+++ b/tests/data/care_plan/care_plan_part_of.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype PartOf
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanPartOfTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "part_of_reference": None,
+        "part_of_display": "Overall wellness plan",
+        "part_of_type": None,
+    },
+]
+
+
+class CarePlanPartOfTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "part_of"
+    transformer = CarePlanPartOfTransformer
+    expected_table_name = "care_plan_part_of"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_replaces.py
+++ b/tests/data/care_plan/care_plan_replaces.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype Replaces
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanReplacesTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "replaces_reference": None,
+        "replaces_display": "Plan from urgent care clinic",
+        "replaces_type": None,
+    },
+]
+
+
+class CarePlanReplacesTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "replaces"
+    transformer = CarePlanReplacesTransformer
+    expected_table_name = "care_plan_replaces"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -100,11 +100,11 @@ RESOURCE = {
     "basedOn": [{"display": "Management of Type 2 Diabetes"}],
     "replaces": [{"display": "Plan from urgent care clinic"}],
     "partOf": [{"display": "Overall wellness plan"}],
-      "category": [
-    {
-      "text": "Weight management plan"
-    }
-  ],
+    "category": [{"text": "Weight management plan"}],
+    "contributor": {
+        "reference": "Practitioner/example",
+        "display": "Peter Example",
+    },
     "identifier": [
         {
             "use": "official",

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -1,0 +1,185 @@
+RESOURCE = {
+    "resourceType": "CarePlan",
+    "id": "preg",
+    "text": {
+        "status": "additional",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>A maternity care plan (for a pregnant woman).</p>\n      <p>LMP is 1st Jan, 2013 (a great new years party!) The plan has activities to take prenatal vitamins, schedule first antenatal,\n            and 'placeholders' for the second antenatal and delivery (there would be lots of others of course)</p>\n      <p>Note that where is a proposed 'status' element against each activity</p>\n    </div>",
+    },
+    "contained": [
+        {
+            "resourceType": "Condition",
+            "id": "p1",
+            "clinicalStatus": {
+                "coding": [
+                    {
+                        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                        "code": "active",
+                    }
+                ]
+            },
+            "verificationStatus": {
+                "coding": [
+                    {
+                        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                        "code": "confirmed",
+                    }
+                ]
+            },
+            "code": {"text": "pregnancy"},
+            "subject": {"reference": "Patient/1", "display": "Eve Everywoman"},
+        },
+        {
+            "resourceType": "Practitioner",
+            "id": "pr1",
+            "name": [{"family": "Midwife", "given": ["Mavis"]}],
+        },
+        {
+            "resourceType": "Practitioner",
+            "id": "pr2",
+            "name": [{"family": "Obstetrician", "given": ["Oscar"]}],
+        },
+        {
+            "resourceType": "CareTeam",
+            "id": "careteam",
+            "participant": [
+                {
+                    "role": [
+                        {
+                            "coding": [
+                                {
+                                    "system": "http://example.org/mysys",
+                                    "code": "lmc",
+                                }
+                            ],
+                            "text": "Midwife",
+                        }
+                    ],
+                    "member": {"reference": "#pr1", "display": "Mavis Midwife"},
+                },
+                {
+                    "role": [
+                        {
+                            "coding": [
+                                {
+                                    "system": "http://example.org/mysys",
+                                    "code": "obs",
+                                }
+                            ],
+                            "text": "Obstretitian",
+                        }
+                    ],
+                    "member": {
+                        "reference": "#pr2",
+                        "display": "Oscar Obstetrician",
+                    },
+                },
+            ],
+        },
+        {
+            "resourceType": "Goal",
+            "id": "goal",
+            "lifecycleStatus": "active",
+            "description": {
+                "text": "Maintain patient's health throughout pregnancy and ensure a healthy child"
+            },
+            "subject": {"reference": "Patient/1", "display": "Eve Everywoman"},
+        },
+    ],
+    "extension": [
+        {
+            "url": "http://example.org/fhir/StructureDefinition/careplan#lmp",
+            "valueDateTime": "2013-01-01",
+        }
+    ],
+    "status": "active",
+    "intent": "plan",
+    "subject": {"reference": "Patient/1", "display": "Eve Everywoman"},
+    "period": {"start": "2013-01-01", "end": "2013-10-01"},
+    "careTeam": [{"reference": "#careteam"}],
+    "addresses": [{"reference": "#p1", "display": "pregnancy"}],
+    "goal": [{"reference": "#goal"}],
+    "activity": [
+        {"reference": {"display": "Prenatal vitamin MedicationRequest"}},
+        {
+            "extension": [
+                {
+                    "url": "http://example.org/fhir/StructureDefinition/careplan#andetails",
+                    "valueUri": "http://orionhealth.com/fhir/careplan/1andetails",
+                }
+            ],
+            "detail": {
+                "kind": "Appointment",
+                "code": {
+                    "coding": [
+                        {"system": "http://example.org/mySystem", "code": "1an"}
+                    ],
+                    "text": "First Antenatal encounter",
+                },
+                "status": "scheduled",
+                "doNotPerform": False,
+                "scheduledTiming": {
+                    "repeat": {
+                        "boundsPeriod": {
+                            "start": "2013-02-14",
+                            "end": "2013-02-28",
+                        }
+                    }
+                },
+                "performer": [
+                    {"reference": "#pr1", "display": "Mavis Midwife"}
+                ],
+                "description": "The first antenatal encounter. This is where a detailed physical examination is performed.             and the pregnanacy discussed with the mother-to-be.",
+            },
+        },
+        {
+            "detail": {
+                "kind": "Appointment",
+                "code": {
+                    "coding": [
+                        {"system": "http://example.org/mySystem", "code": "an"}
+                    ],
+                    "text": "Follow-up Antenatal encounter",
+                },
+                "status": "not-started",
+                "doNotPerform": False,
+                "scheduledTiming": {
+                    "repeat": {
+                        "boundsPeriod": {
+                            "start": "2013-03-01",
+                            "end": "2013-03-14",
+                        }
+                    }
+                },
+                "performer": [
+                    {"reference": "#pr1", "display": "Mavis Midwife"}
+                ],
+                "description": "The second antenatal encounter. Discuss any issues that arose from the first antenatal encounter",
+            }
+        },
+        {
+            "detail": {
+                "kind": "Appointment",
+                "code": {
+                    "coding": [
+                        {"system": "http://example.org/mySystem", "code": "del"}
+                    ],
+                    "text": "Delivery",
+                },
+                "status": "not-started",
+                "doNotPerform": False,
+                "scheduledTiming": {
+                    "repeat": {
+                        "boundsPeriod": {
+                            "start": "2013-09-01",
+                            "end": "2013-09-14",
+                        }
+                    }
+                },
+                "performer": [
+                    {"reference": "#pr1", "display": "Mavis Midwife"}
+                ],
+                "description": "The delivery.",
+            }
+        },
+    ],
+}

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -98,6 +98,8 @@ RESOURCE = {
         "http://example.org/fhir/CarePlanDefinition/KDN5"
     ],
     "basedOn": [{"display": "Management of Type 2 Diabetes"}],
+    "replaces": [{"display": "Plan from urgent care clinic"}],
+    "partOf": [{"display": "Overall wellness plan"}],
     "identifier": [
         {
             "use": "official",

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -93,6 +93,10 @@ RESOURCE = {
     ],
     "status": "active",
     "intent": "plan",
+    "instantiatesUri": ["http://example.org/protocol-for-obesity"],
+    "instantiatesCanonical": [
+        "http://example.org/fhir/CarePlanDefinition/KDN5"
+    ],
     "identifier": [
         {
             "use": "official",

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -116,6 +116,7 @@ RESOURCE = {
     "period": {"start": "2013-01-01", "end": "2013-10-01"},
     "careTeam": [{"reference": "#careteam"}],
     "addresses": [{"reference": "#p1", "display": "pregnancy"}],
+    "supportingInfo": [{"reference": "#support", "display": "support"}],
     "goal": [{"reference": "#goal"}],
     "activity": [
         {"reference": {"display": "Prenatal vitamin MedicationRequest"}},

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -202,4 +202,10 @@ RESOURCE = {
             }
         },
     ],
+    "note": [
+        {
+            "text": "Patient family is not ready to commit to goal setting at this time.  Goal setting will be addressed in the future",
+            "time": "2014-02-14",
+        }
+    ],
 }

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -100,6 +100,11 @@ RESOURCE = {
     "basedOn": [{"display": "Management of Type 2 Diabetes"}],
     "replaces": [{"display": "Plan from urgent care clinic"}],
     "partOf": [{"display": "Overall wellness plan"}],
+      "category": [
+    {
+      "text": "Weight management plan"
+    }
+  ],
     "identifier": [
         {
             "use": "official",

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -93,6 +93,13 @@ RESOURCE = {
     ],
     "status": "active",
     "intent": "plan",
+    "identifier": [
+        {
+            "use": "official",
+            "system": "http://www.bmc.nl/zorgportal/identifiers/careplans",
+            "value": "CP2903",
+        }
+    ],
     "subject": {"reference": "Patient/1", "display": "Eve Everywoman"},
     "period": {"start": "2013-01-01", "end": "2013-10-01"},
     "careTeam": [{"reference": "#careteam"}],

--- a/tests/data/care_plan/care_plan_resource.py
+++ b/tests/data/care_plan/care_plan_resource.py
@@ -97,6 +97,7 @@ RESOURCE = {
     "instantiatesCanonical": [
         "http://example.org/fhir/CarePlanDefinition/KDN5"
     ],
+    "basedOn": [{"display": "Management of Type 2 Diabetes"}],
     "identifier": [
         {
             "use": "official",

--- a/tests/data/care_plan/care_plan_supporting_info.py
+++ b/tests/data/care_plan/care_plan_supporting_info.py
@@ -1,0 +1,49 @@
+"""
+Test helper class for FHIR resource type CarePlan subtype SupportingInfo
+"""
+
+from radiant_fhir_transform_cli.transform.classes import (
+    CarePlanSupportingInfoTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .care_plan import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "care_plan_id": "preg",
+        "supporting_info_reference": "#support",
+        "supporting_info_display": "support",
+        "supporting_info_type": None,
+    },
+]
+
+
+class CarePlanSupportingInfoTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'CarePlan' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'CarePlan' resource.
+
+    It predefines the resource type as 'CarePlan'
+    and initializes the resource with the specific 'CarePlan' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'CarePlan'.
+
+        resource (dict): The raw FHIR 'CarePlan' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'CarePlan' resource payload.
+    """
+
+    resource_type = "CarePlan"
+    resource_subtype = "supporting_info"
+    transformer = CarePlanSupportingInfoTransformer
+    expected_table_name = "care_plan_supporting_info"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)


### PR DESCRIPTION
@liberaliscomputing and @awarkow can you review this and especially can you give extra review to Activity transformer? That one was very complicated so I could use extra eyes on it.

Once we can handle nested lists, CarePlan transformer will still need:

Category.coding
Activity.outcomeCodeableConcept
Activity.outcome.reference
Activity.progress
Activity.detail.instantiatesCanonical
Activity.detail.instantiatesUri
Activity.detail.reasonCode
Activity.detail.goal
Activity.detail.performer
Activity.detail.scheduledTiming.event
Activity.detail.scheduledTiming.dayOfWeek
Activity.detail.scheduledTiming.timeOfDay
Activity.detail.scheduledTiming.when

