### PR TITLE
🐛 [PLAT-349] Fix Typo in Immunization Mapping

### DIFF
--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -705,7 +705,7 @@ transformers = {
         RequestGroupNoteTransformer,
         RequestGroupActionTransformer,
     ],
-    "Immunizationformer": [
+    "Immunization": [
         ImmunizationTransformer,
         ImmunizationIdentifierTransformer,
         ImmunizationStatusReasonCodingTransformer,


### PR DESCRIPTION
This PR fixes typo in the Immunization resource type and transformer classes mapping. This PR closes #78.