### PR TITLE
update medication ingredient transformer to include reference and cod…

### DIFF
--- a/radiant_fhir_transform_cli/transform/classes/medication/medication_ingredient.py
+++ b/radiant_fhir_transform_cli/transform/classes/medication/medication_ingredient.py
@@ -51,6 +51,14 @@ TRANSFORM_SCHEMA = [
     {
         "fhir_path": "ingredient",
         "columns": {
+            "ingredient_item_codeable_concept": {
+                "fhir_key": "itemCodeableConcept",
+                "type": "str",
+            },
+            "ingredient_item_reference": {
+                "fhir_key": "itemReference",
+                "type": "str",
+            },
             "ingredient_is_active": {"fhir_key": "isActive", "type": "bool"},
             "ingredient_strength_numerator_value": {
                 "fhir_key": "strength.numerator.value",

--- a/tests/data/medication/medication_ingredient.py
+++ b/tests/data/medication/medication_ingredient.py
@@ -16,6 +16,19 @@ from .medication_resource import RESOURCE
 EXPECTED_OUTPUT = [
     {
         "medication_id": "med0301",
+        "ingredient_item_codeable_concept": {
+            "coding": [
+                {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "code": "66955",
+                    "display": "Vancomycin Hydrochloride",
+                }
+            ]
+        },
+        "ingredient_item_reference": {
+            "reference": "Medication/abcd",
+            "display": "potassium phosphate",
+        },
         "ingredient_is_active": True,
         "ingredient_strength_numerator_value": 500,
         "ingredient_strength_numerator_unit": None,

--- a/tests/data/medication/medication_resource.py
+++ b/tests/data/medication/medication_resource.py
@@ -45,6 +45,10 @@ RESOURCE = {
                     }
                 ]
             },
+            "itemReference": {
+                "reference": "Medication/abcd",
+                "display": "potassium phosphate",
+            },
             "isActive": True,
             "strength": {
                 "numerator": {


### PR DESCRIPTION
Closes D3B-1909

In working on some medication querying with Jeritt, we discovered that medication ingredient codeable concepts and references are not being extracted to the database tables in any form. This causes major usability issues because for compounded or custom medications, the only way to know what their actual makeup is is to check the ingredients.  Not extracting these items means we have no way to connect to that info.

When looking at the transformer, I saw that the portion of code that should deal with ingredient codeable concept and reference was commented out, due to lack of support for nested lists.  I suspect this was done **before** we agreed as a team that all nested lists should still be extracted, even if they cannot be properly formatted into the expected structure (see decision documentation [here](https://docs.google.com/document/d/1dNkD8fUCsp-yz0ltc1QJ6XnuLP_pWQQYSEnpn1nkcoE/edit?tab=t.0)). 

This PR updates the medication_ingredient transformer to align with the decision(s) documented and to extract these important items.  It also updates the related unit tests.