### PR TITLE
✨ [PLAT-1137] Add Data Absent Reason Extension Extraction for Procedure

### DIFF
--- a/radiant_fhir_transform_cli/transform/classes/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/__init__.py
@@ -133,6 +133,7 @@ from radiant_fhir_transform_cli.transform.classes.medication_dispense import (
 
 from radiant_fhir_transform_cli.transform.classes.procedure import (
     ProcedureTransformer,
+    ProcedureDataAbsentReasonTransformer,
     ProcedureIdentifierTransformer,
     ProcedureInstantiatesCanonicalTransformer,
     ProcedureInstantiatesUriTransformer,
@@ -599,6 +600,7 @@ transformers = {
     ],
     "Procedure": [
         ProcedureTransformer,
+        ProcedureDataAbsentReasonTransformer,
         ProcedureIdentifierTransformer,
         ProcedureInstantiatesCanonicalTransformer,
         ProcedureInstantiatesUriTransformer,

--- a/radiant_fhir_transform_cli/transform/classes/procedure/__init__.py
+++ b/radiant_fhir_transform_cli/transform/classes/procedure/__init__.py
@@ -1,4 +1,5 @@
 from .procedure import ProcedureTransformer
+from .procedure_data_absent_reason import ProcedureDataAbsentReasonTransformer
 from .procedure_identifier import ProcedureIdentifierTransformer
 from .procedure_instantiates_canonical import (
     ProcedureInstantiatesCanonicalTransformer,

--- a/radiant_fhir_transform_cli/transform/classes/procedure/procedure_data_absent_reason.py
+++ b/radiant_fhir_transform_cli/transform/classes/procedure/procedure_data_absent_reason.py
@@ -1,0 +1,48 @@
+"""FHIR Procedure data_absent_reason transformer"""
+
+from radiant_fhir_transform_cli.transform.classes.base import (
+    FhirResourceTransformer,
+)
+
+VIEW_DEFINITION = {
+    "resource": "Procedure",
+    "name": "procedure_data_absent_reason",
+    "status": "active",
+    "constant": [
+        {
+            "name": "id_hash",
+            "valueString": "hash_row()",
+        },
+    ],
+    "select": [
+        {
+            "column": [
+                {
+                    "name": "id",
+                    "path": "%id_hash",
+                    "type": "string",
+                },
+                {
+                    "name": "procedure_id",
+                    "path": "id",
+                    "type": "string",
+                },
+            ],
+        },
+        {
+            "forEachOrNull": "extension",
+            "column": [
+                {
+                    "name": "value_code",
+                    "path": "$this.where(url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason').valueCode",
+                    "type": "string",
+                },
+            ],
+        },
+    ],
+}
+
+
+class ProcedureDataAbsentReasonTransformer(FhirResourceTransformer):
+    def __init__(self):
+        super().__init__("Procedure", "data_absent_reason", VIEW_DEFINITION)

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -316,6 +316,7 @@ from tests.data.procedure import (
     ProcedureCodeCodingTestHelper,
     ProcedureComplicationDetailTestHelper,
     ProcedureComplicationTestHelper,
+    ProcedureDataAbsentReasonTestHelper,
     ProcedureFocalDeviceTestHelper,
     ProcedureFollowUpTestHelper,
     ProcedureIdentifierTestHelper,
@@ -329,9 +330,9 @@ from tests.data.procedure import (
     ProcedureReasonReferenceTestHelper,
     ProcedureReportTestHelper,
     ProcedureStatusReasonCodingTestHelper,
-    ProcedureTestHelper,
     ProcedureUsedCodeTestHelper,
     ProcedureUsedReferenceTestHelper,
+    ProcedureTestHelper,
 )
 from tests.data.provenance import (
     ProvenanceActivityCodingTestHelper,
@@ -574,6 +575,7 @@ test_helpers = [
     OrganizationContactTestHelper,
     OrganizationEndpointTestHelper,
     ProcedureTestHelper,
+    ProcedureDataAbsentReasonTestHelper,
     ProcedureIdentifierTestHelper,
     ProcedureInstantiatesCanonicalTestHelper,
     ProcedureInstantiatesUriTestHelper,

--- a/tests/data/procedure/__init__.py
+++ b/tests/data/procedure/__init__.py
@@ -1,4 +1,5 @@
 from .procedure import ProcedureTestHelper
+from .procedure_data_absent_reason import ProcedureDataAbsentReasonTestHelper
 from .procedure_identifier import ProcedureIdentifierTestHelper
 from .procedure_instantiates_canonical import (
     ProcedureInstantiatesCanonicalTestHelper,

--- a/tests/data/procedure/procedure_data_absent_reason.py
+++ b/tests/data/procedure/procedure_data_absent_reason.py
@@ -1,0 +1,48 @@
+"""
+Test helper class for FHIR resource type Procedure subtype DataAbsentReason
+"""
+
+from radiant_fhir_transform_cli.transform.classes.procedure import (
+    ProcedureDataAbsentReasonTransformer,
+)
+from tests.data.base import FhirResourceTestHelper
+
+from .procedure_resource import RESOURCE
+
+EXPECTED_OUTPUT = [
+    {
+        "value_code": "not-applicable",
+        "id": "3a62cbdb-df70-4663-a3a2-02692652efc5",
+        "procedure_id": "f201",
+    },
+]
+
+
+class ProcedureDataAbsentReasonTestHelper(FhirResourceTestHelper):
+    """
+    A helper class for testing transformations of the FHIR 'Procedure' resource.
+
+    This class extends the FhirResourceTestHelper and is specifically
+    designed to assist in testing the transformation of the 'Procedure' resource.
+
+    It predefines the resource type as 'Procedure'
+    and initializes the resource with the specific 'Procedure' resource payload
+    and its expected transformation output.
+
+    Attributes:
+        resource_type (str): The type of FHIR resource being tested, which
+          is set to 'Procedure'.
+
+        resource (dict): The raw FHIR 'Procedure' resource payload to be tested.
+
+        expected_output (dict): The expected transformation result of the
+          'Procedure' resource payload.
+    """
+
+    resource_type = "Procedure"
+    resource_component = "data_absent_reason"
+    transformer = ProcedureDataAbsentReasonTransformer
+    expected_table_name = "procedure_data_absent_reason"
+
+    def __init__(self):
+        super().__init__(RESOURCE, EXPECTED_OUTPUT)

--- a/tests/data/procedure/procedure_resource.py
+++ b/tests/data/procedure/procedure_resource.py
@@ -1,6 +1,12 @@
 RESOURCE = {
     "resourceType": "Procedure",
     "id": "f201",
+    "extension": [
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode": "not-applicable",
+        }
+    ],
     "identifier": [
         {
             "use": "usual",


### PR DESCRIPTION
Adds support for extracting the *Data Absent Reason* extension for the Procedure resource and exposing it in a queryable format. Specifically, this PR extracts extension data from:

```
extension.where(url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason')
```

and populates a new table:

* `procedure_data_absent_reason`

  * `procedure_id`
  * `value_code`

---

### **What’s Changed**

* Introduced new table: `procedure_data_absent_reason`
* Extracted `valueCode` from the *Data Absent Reason* extension
* Linked extracted values back to the parent Procedure via `procedure_id`

---

### **Why This Change**

FHIR Procedure resources may include the *Data Absent Reason* extension to indicate why a value (e.g., performed period) is missing.

Without this extraction:

* important semantic context is lost
* downstream users cannot distinguish between “missing” vs “intentionally absent” data

This change:

* improves data completeness
* enables explicit identification of absent data scenarios
* aligns with selective promotion of high-value extension data into relational structures

---

### **Scope**

* ✅ Procedure resource only
* ✅ Data Absent Reason extension (`valueCode`)
* ❌ No changes to other extensions or resources

---

### **Relevant Issue(s)**

* https://d3b.atlassian.net/browse/PLAT-1137
